### PR TITLE
Rename project from Slip Scanner to Avers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,18 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "slip_scanner",
+            "name": "avers",
             "request": "launch",
             "type": "dart"
         },
         {
-            "name": "slip_scanner (profile mode)",
+            "name": "avers (profile mode)",
             "request": "launch",
             "type": "dart",
             "flutterMode": "profile"
         },
         {
-            "name": "slip_scanner (release mode)",
+            "name": "avers (release mode)",
             "request": "launch",
             "type": "dart",
             "flutterMode": "release"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,8 @@ Type-safe routing with `@RoutePage` annotations. Routes defined in `lib/router/a
 
 ### Platform Channels
 
-- `com.example.slip_scanner/vision` — OCR operations (scanAllPhotos, cancelScanning, scanPaymentSlip, deleteSlipImage, loadImageFromAsset, processImageData)
-- `com.example.slip_scanner/progress` — Real-time callbacks (onProgress, onPartialResults) via `DispatchQueue.main.async`
+- `com.avers.app/vision` — OCR operations (scanAllPhotos, cancelScanning, scanPaymentSlip, deleteSlipImage, loadImageFromAsset, processImageData)
+- `com.avers.app/progress` — Real-time callbacks (onProgress, onPartialResults) via `DispatchQueue.main.async`
 
 ### On-Device AI Pipeline (CactusLM + RAG)
 

--- a/MIGRATION_COMPLETE.md
+++ b/MIGRATION_COMPLETE.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Successfully migrated **slip_scanner** from `shadcn_ui` to **ForUI** design system with **FScaffold** implementation.
+Successfully migrated **avers** from `shadcn_ui` to **ForUI** design system with **FScaffold** implementation.
 
 ### Migration Date
 January 4, 2026

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Slip Scanner
+# Avers
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/GChanathip/slip_scanner?utm_source=oss&utm_medium=github&utm_campaign=GChanathip%2Fslip_scanner&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 Flutter app (iOS + macOS) that scans payment slips using Apple Vision Framework OCR. Specializes in Thai banking slips (SCB, KBank Make/K Plus, Dime) with Thai language text recognition, Buddhist calendar conversion, and on-device LLM extraction via CactusLM.

--- a/docs/CACTUS_INTEGRATION.md
+++ b/docs/CACTUS_INTEGRATION.md
@@ -1,10 +1,10 @@
 # Cactus LLM Integration Summary
 
-This document summarizes the integration of Cactus Flutter LLM into the Slip Scanner app for AI-powered expense analysis.
+This document summarizes the integration of Cactus Flutter LLM into the Avers app for AI-powered expense analysis.
 
 ## Overview
 
-The Slip Scanner app now includes on-device AI capabilities using the Cactus Flutter plugin. Users can:
+The Avers app now includes on-device AI capabilities using the Cactus Flutter plugin. Users can:
 - Get AI-powered insights about their spending patterns
 - Chat with an AI assistant about their expenses
 - Have slips automatically enriched with extracted recipient, notes, and category data

--- a/docs/FORUI_MIGRATION_SUMMARY.md
+++ b/docs/FORUI_MIGRATION_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Migration Completed: January 4, 2026
 
-Successfully migrated slip_scanner from `shadcn_ui` to `ForUI` design system.
+Successfully migrated avers from `shadcn_ui` to `ForUI` design system.
 
 ## Changes Overview
 

--- a/docs/research/bank-coverage-expansion.md
+++ b/docs/research/bank-coverage-expansion.md
@@ -2,7 +2,7 @@
 
 ## User Segment
 
-Thai users of the Slip Scanner app who transact with banks beyond SCB, KBank, and Dime — primarily Bangkok Bank, Krungthai Bank, Krungsri, ttb, and Government Savings Bank account holders who currently get no OCR extraction from their payment slips.
+Thai users of the Avers app who transact with banks beyond SCB, KBank, and Dime — primarily Bangkok Bank, Krungthai Bank, Krungsri, ttb, and Government Savings Bank account holders who currently get no OCR extraction from their payment slips.
 
 ## Problem Statement
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -628,7 +628,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -646,7 +646,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -665,7 +665,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -682,7 +682,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -815,7 +815,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -839,7 +839,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -13,11 +13,11 @@ import UIKit
         let controller = window?.rootViewController as! FlutterViewController
 
         let progressChannel = FlutterMethodChannel(
-            name: "com.example.slip_scanner/progress",
+            name: "com.avers.app/progress",
             binaryMessenger: controller.binaryMessenger
         )
         let visionChannel = FlutterMethodChannel(
-            name: "com.example.slip_scanner/vision",
+            name: "com.avers.app/vision",
             binaryMessenger: controller.binaryMessenger
         )
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Slip Scanner</string>
+	<string>Avers</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>slip_scanner</string>
+	<string>avers</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
-      title: 'Payment Slip Scanner',
+      title: 'Avers',
       debugShowCheckedModeBanner: false,
       locale: const Locale('en', 'US'),
       localizationsDelegates: FLocalizations.localizationsDelegates,

--- a/lib/screens/analysis_screen.dart
+++ b/lib/screens/analysis_screen.dart
@@ -4,7 +4,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:forui/forui.dart';
-import 'package:slip_scanner/providers/budget_state.dart';
+import 'package:avers/providers/budget_state.dart';
 import '../providers/analysis_provider.dart';
 import '../providers/analysis_state.dart';
 import '../providers/budget_provider.dart';

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -263,7 +263,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final budgetState = ref.watch(budgetProvider);
 
     return FScaffold(
-      header: const FHeader(title: Text('Payment Slip Scanner')),
+      header: const FHeader(title: Text('Avers')),
       child: Stack(
         children: [
           _isLoading
@@ -417,7 +417,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                       icon: Icon(FIcons.lightbulb, color: theme.colors.primary),
                       title: const Text('Getting Started'),
                       subtitle: const Text(
-                        'Welcome to Payment Slip Scanner! This app automatically finds and tracks payment slips in your photo library.\n\n'
+                        'Welcome to Avers! This app automatically finds and tracks payment slips in your photo library.\n\n'
                         '• Tap "Scan All Photos" to start\n'
                         '• The app will find payment amounts and dates\n'
                         '• View your spending organized by month\n'

--- a/lib/screens/server_dashboard_screen.dart
+++ b/lib/screens/server_dashboard_screen.dart
@@ -170,7 +170,7 @@ class _ServerDashboardScreenState extends ConsumerState<ServerDashboardScreen> {
 
     return FScaffold(
       header: FHeader(
-        title: const Text('Slip Scanner Server'),
+        title: const Text('Avers Server'),
       ),
       child: SingleChildScrollView(
         padding: const EdgeInsets.all(16),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,7 +3,7 @@ import 'package:cactus/cactus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:forui/forui.dart';
-import 'package:slip_scanner/providers/cactus_state.dart';
+import 'package:avers/providers/cactus_state.dart';
 import '../providers/cactus_provider.dart';
 import '../providers/extraction_provider.dart';
 import '../router/app_router.dart';

--- a/lib/services/platform_service.dart
+++ b/lib/services/platform_service.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 
 class PlatformService {
-  static const MethodChannel _channel = MethodChannel('com.example.slip_scanner/vision');
-  static const MethodChannel _progressChannel = MethodChannel('com.example.slip_scanner/progress');
+  static const MethodChannel _channel = MethodChannel('com.avers.app/vision');
+  static const MethodChannel _progressChannel = MethodChannel('com.avers.app/progress');
 
   static StreamController<Map<String, dynamic>>? _progressController;
   static StreamController<Map<String, dynamic>>? _partialResultsController;

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -78,7 +78,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* slip_scanner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = slip_scanner.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* avers.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = avers.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -166,7 +166,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* slip_scanner.app */,
+				33CC10ED2044A3C60003C045 /* avers.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -289,7 +289,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* slip_scanner.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* avers.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -529,10 +529,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/slip_scanner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/slip_scanner";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/avers.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/avers";
 			};
 			name = Debug;
 		};
@@ -544,10 +544,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/slip_scanner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/slip_scanner";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/avers.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/avers";
 			};
 			name = Release;
 		};
@@ -559,10 +559,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.avers.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/slip_scanner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/slip_scanner";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/avers.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/avers";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "slip_scanner.app"
+               BuildableName = "avers.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "slip_scanner.app"
+            BuildableName = "avers.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "slip_scanner.app"
+            BuildableName = "avers.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "slip_scanner.app"
+            BuildableName = "avers.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -11,7 +11,7 @@ class AppDelegate: FlutterAppDelegate {
         }
 
         let visionChannel = FlutterMethodChannel(
-            name: "com.example.slip_scanner/vision",
+            name: "com.avers.app/vision",
             binaryMessenger: controller.engine.binaryMessenger
         )
 

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = slip_scanner
+PRODUCT_NAME = avers
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = avers
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.slipScanner
+PRODUCT_BUNDLE_IDENTIFIER = com.avers.app
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 Avers. All rights reserved.

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,7 +12,7 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.example.slipScanner</string>
+		<string>$(AppIdentifierPrefix)com.avers.app</string>
 	</array>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Avers</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -12,7 +12,7 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.example.slipScanner</string>
+		<string>$(AppIdentifierPrefix)com.avers.app</string>
 	</array>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: slip_scanner
+name: avers
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.

--- a/test/budget_provider_test.dart
+++ b/test/budget_provider_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:slip_scanner/providers/budget_provider.dart';
-import 'package:slip_scanner/providers/budget_state.dart';
+import 'package:avers/providers/budget_provider.dart';
+import 'package:avers/providers/budget_state.dart';
 
 void main() {
   group('BudgetProvider', () {

--- a/test/budget_service_test.dart
+++ b/test/budget_service_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:slip_scanner/services/budget_service.dart';
+import 'package:avers/services/budget_service.dart';
 
 void main() {
   group('BudgetService', () {

--- a/test/budget_state_test.dart
+++ b/test/budget_state_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:slip_scanner/providers/budget_state.dart';
+import 'package:avers/providers/budget_state.dart';
 
 void main() {
   group('BudgetAlert', () {

--- a/test/category_edge_cases_test.dart
+++ b/test/category_edge_cases_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:slip_scanner/services/category_service.dart';
+import 'package:avers/services/category_service.dart';
 
 Future<Database> _openTestDb() async {
   final db = await databaseFactoryFfi.openDatabase(

--- a/test/category_edit_sheet_test.dart
+++ b/test/category_edit_sheet_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:slip_scanner/widgets/category_edit_sheet.dart';
+import 'package:avers/widgets/category_edit_sheet.dart';
 
 void main() {
   group('CategoryEditSheet Widget Tests', () {

--- a/test/category_learning_integration_test.dart
+++ b/test/category_learning_integration_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:slip_scanner/services/category_service.dart';
+import 'package:avers/services/category_service.dart';
 
 Future<Database> _openTestDb() async {
   final db = await databaseFactoryFfi.openDatabase(

--- a/test/category_management_screen_test.dart
+++ b/test/category_management_screen_test.dart
@@ -14,9 +14,6 @@ void main() {
         ),
       );
 
-      // Wait for async providers to load
-      await tester.pumpAndSettle();
-
       // Verify built-in categories displayed
       expect(find.text('Food'), findsOneWidget);
       expect(find.text('Transport'), findsOneWidget);

--- a/test/category_management_screen_test.dart
+++ b/test/category_management_screen_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:slip_scanner/screens/category_management_screen.dart';
+import 'package:avers/screens/category_management_screen.dart';
 
 void main() {
   group('CategoryManagementScreen Widget Tests', () {
@@ -13,6 +13,9 @@ void main() {
           ),
         ),
       );
+
+      // Wait for async providers to load
+      await tester.pumpAndSettle();
 
       // Verify built-in categories displayed
       expect(find.text('Food'), findsOneWidget);

--- a/test/category_regression_test.dart
+++ b/test/category_regression_test.dart
@@ -5,9 +5,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:slip_scanner/models/payment_slip.dart';
-import 'package:slip_scanner/models/category_registry.dart';
-import 'package:slip_scanner/services/category_service.dart';
+import 'package:avers/models/payment_slip.dart';
+import 'package:avers/models/category_registry.dart';
+import 'package:avers/services/category_service.dart';
 
 Future<Database> _openTestDb() async {
   final db = await databaseFactoryFfi.openDatabase(

--- a/test/category_service_test.dart
+++ b/test/category_service_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:slip_scanner/services/category_service.dart';
+import 'package:avers/services/category_service.dart';
 
 // ─── Minimal v7 schema (only tables CategoryService touches) ─────────────────
 

--- a/test/extraction_service_custom_categories_test.dart
+++ b/test/extraction_service_custom_categories_test.dart
@@ -3,8 +3,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:slip_scanner/services/category_service.dart';
-import 'package:slip_scanner/services/extraction_service.dart';
+import 'package:avers/services/category_service.dart';
+import 'package:avers/services/extraction_service.dart';
 
 // ─── Minimal in-memory DB (same schema as category_service_test) ─────────────
 

--- a/test/monthly_summary_test.dart
+++ b/test/monthly_summary_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:slip_scanner/models/monthly_summary.dart';
+import 'package:avers/models/monthly_summary.dart';
 
 void main() {
   group('MonthlySummary', () {

--- a/test/scanning_conversion_test.dart
+++ b/test/scanning_conversion_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:slip_scanner/utils/slip_conversion.dart';
+import 'package:avers/utils/slip_conversion.dart';
 
 void main() {
   group('nonEmpty', () {

--- a/test/suggestion_chip_service_test.dart
+++ b/test/suggestion_chip_service_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:slip_scanner/providers/analysis_state.dart';
-import 'package:slip_scanner/providers/budget_state.dart';
-import 'package:slip_scanner/services/suggestion_chip_service.dart';
+import 'package:avers/providers/analysis_state.dart';
+import 'package:avers/providers/budget_state.dart';
+import 'package:avers/services/suggestion_chip_service.dart';
 
 void main() {
   group('SuggestionChipService.generate', () {

--- a/test/suggestion_chips_bar_test.dart
+++ b/test/suggestion_chips_bar_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forui/forui.dart';
-import 'package:slip_scanner/models/suggestion_chip.dart' as model;
-import 'package:slip_scanner/widgets/suggestion_chips_bar.dart';
+import 'package:avers/models/suggestion_chip.dart' as model;
+import 'package:avers/widgets/suggestion_chips_bar.dart';
 
 /// Wraps a widget in the minimum forui + Material scaffolding needed for tests.
 Widget _testApp(Widget child) {

--- a/test/what_if_scenario_test.dart
+++ b/test/what_if_scenario_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:slip_scanner/models/what_if_scenario.dart';
+import 'package:avers/models/what_if_scenario.dart';
 
 void main() {
   group('WhatIfScenario', () {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:slip_scanner/main.dart';
+import 'package:avers/main.dart';
 
 void main() {
   testWidgets('App builds without errors', (WidgetTester tester) async {

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "slip_scanner",
-    "short_name": "slip_scanner",
+    "name": "avers",
+    "short_name": "avers",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
## Summary
- Rename Flutter package from `slip_scanner` to `avers` (`pubspec.yaml`, all Dart imports)
- Update all user-facing strings: "Payment Slip Scanner" → "Avers", "Slip Scanner Server" → "Avers Server"
- Update platform channel identifiers from `com.example.slip_scanner` to `com.avers.app` (Dart, iOS, macOS)
- Update iOS/macOS bundle names and display names
- Update documentation, VS Code launch configs, and web manifest

## Test plan
- [x] `build_runner` code generation verified
- [x] `flutter analyze` clean (info-only)
- [x] Tests pass (pre-existing failures unchanged)
- [ ] Verify iOS build and platform channel communication
- [ ] Verify macOS build and LINE bot server functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rebranded application from "Slip Scanner" to "Avers" across platforms (iOS, macOS, web, and Flutter).
  * Updated platform channel identifiers and package/bundle names to match new branding.
  * Updated user-facing titles, headings, and welcome text throughout the app.
  * Updated documentation and tests to reference the new application name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->